### PR TITLE
display: remember the last pointer position when border trigger is disabled

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_PROJECT_DESCRIPTION
 
 set(lmss_VERSION_MAJOR 4)
 set(lmss_VERSION_MINOR 2)
-set(lmss_VERSION_PATCH 2)
+set(lmss_VERSION_PATCH 3)
 
 include(GNUInstallDirs)
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -216,6 +216,7 @@ void display::handle_events(int) {
 
             if (mask & (Button1Mask | Button2Mask | Button3Mask | Button4Mask | Button5Mask)) {
                 log.debug("mouse button pressed, skipping border detection");
+                last_pos = { root_x, root_y, root };
                 continue;
             }
 


### PR DESCRIPTION
We still need to remember the last pointer position when the border trigger is disabled (a mouse button is pressed) so we don't trigger a border on the next move when the mouse button is released and we've moved to a different screen.