### PR TITLE
display: don't assume a monitor with screen position 0,0 exists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,39 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.3.1] - 2026-06-02
+
+### Fixed
+- don't assume a monitor with screen position 0,0 exists
+
+## [4.3.0] - 2025-10-02
+
+### Fixed
+- fix 100% CPU usage when waiting for mouse position from USB device
+
+## [4.2.3] - 2024-04-24
+
+### Changed
+- smarttouch firmware 8.7 (26.03.2024) or newer is required since LMSS 4.2.x
+
+### Fixed
+- fix border trigger when mouse button is pressed and released on different screens
+
+## [4.2.2] - 2024-03-28
+
+### Changed
+- set border clearance to 1pxl
+
+## [4.2.1] - 2024-03-28
+
+### Fixed
+- fix X root window when using manual screen layout configuration
+
+## [4.2.0] - 2024-03-26
+
+### Fixed
+- only trigger border when we got a position response for the last border triggered
+
 ## [4.1.2] - 2024-03-14
 
 ### Changed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_PROJECT_DESCRIPTION
 
 set(lmss_VERSION_MAJOR 4)
 set(lmss_VERSION_MINOR 3)
-set(lmss_VERSION_PATCH 0)
+set(lmss_VERSION_PATCH 1)
 
 include(GNUInstallDirs)
 

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -215,30 +215,34 @@ void display::handle_events(int) {
 
             log.debug("pointer: " + std::to_string(root_x) + "/" + std::to_string(root_y));
 
+            if (!last_pos.has_value()) {
+                last_pos = { root_x, root_y, root };
+            }
+
             if (mask & (Button1Mask | Button2Mask | Button3Mask | Button4Mask | Button5Mask)) {
                 log.debug("mouse button pressed, skipping border detection");
                 last_pos = { root_x, root_y, root };
                 continue;
             }
 
-            auto const & m_last = get_mon_for_pos(last_pos);
+            auto const & m_last = get_mon_for_pos(*last_pos);
             auto const & m_cur = get_mon_for_pos({root_x, root_y, root});
-            auto diff_x = std::abs(root_x - last_pos.x);
-            auto diff_y = std::abs(root_y - last_pos.y);
+            auto diff_x = std::abs(root_x - last_pos->x);
+            auto diff_y = std::abs(root_y - last_pos->y);
             uint16_t pos = 0;
             border_t border;
 
             // we need to check if we crossed a border since last pointer update
-            if (root != last_pos.root) {
+            if (root != last_pos->root) {
                 if (diff_x < diff_y) { // top/bottom
-                    pos = RESOLUTION * (last_pos.x - m_last.x) / m_last.w;
+                    pos = RESOLUTION * (last_pos->x - m_last.x) / m_last.w;
                     if (root_y < m_cur.h / 2) { // top
                         border = border_t::TOP;
                     } else { //bottom
                         border =  border_t::BOTTOM;
                     }
                 } else { // left/right
-                    pos = RESOLUTION * (last_pos.y - m_last.y) / m_last.h;
+                    pos = RESOLUTION * (last_pos->y - m_last.y) / m_last.h;
                     if (root_x < m_cur.w / 2) { // right
                         border = border_t::RIGHT;
                     } else { // left

--- a/src/display.hpp
+++ b/src/display.hpp
@@ -7,6 +7,7 @@
 #include <X11/extensions/XInput2.h>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -57,7 +58,7 @@ private:
     void add_monitor(int mon, int x, int y, int w, int h, Window);
     void subscribe_to_motion_events(Window);
 
-    pos_t last_pos;
+    std::optional<pos_t> last_pos;
     file_descriptor xfd;
     logger & log;
     context & ctx;

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -4,6 +4,7 @@
 
 #include <sys/timerfd.h>
 
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <functional>


### PR DESCRIPTION
There may be screen configurations where no monitor includes the coordinates 0,0. The last mouse position was initialized with those coordinates and an exception was throws on the first mouse movement when we could not determine on which monitor the pointer was.