### PR TITLE
Reset border wait state after timeout to avoid permanent stall

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- reset the border wait state after a timeout when the device sends no position
+  command (e.g. an outer edge without a configured neighbour), so a single push
+  against a dead edge no longer blocks all further mouse switching
+
 ## [4.3.1] - 2026-06-02
 
 ### Fixed

--- a/src/usb.cpp
+++ b/src/usb.cpp
@@ -15,6 +15,12 @@
 static const char USB_PATH[] = "/dev/bus/usb";
 static const unsigned int TRANSFER_TIMEOUT = 50;
 
+// If the device does not answer a border-cross with a position command within
+// this time (e.g. because the edge has no neighbour configured), drop the
+// waiting state so mouse switching does not get stuck. A valid cross is
+// acknowledged within a few tens of milliseconds, so this is a wide margin.
+static const std::chrono::milliseconds BORDER_RESPONSE_TIMEOUT{500};
+
 usb_dev::usb_dev(logger & log, context & ctx)
     : log(log)
     , ctx(ctx)
@@ -110,6 +116,12 @@ void usb_dev::handle_events(int) {
     }
     while (reap()) { }
 
+    if (last_sent_pos.has_value() &&
+        std::chrono::steady_clock::now() - last_sent_time > BORDER_RESPONSE_TIMEOUT) {
+        log.debug("no position cmd within timeout, resetting border wait state");
+        last_sent_pos.reset();
+    }
+
     if (transfers.empty()) {
         read_mouse_pos();
     }
@@ -189,6 +201,7 @@ void usb_dev::send_mouse_pos(mouse_pos_t const & mp) {
     }
 
     last_sent_pos = mp;
+    last_sent_time = std::chrono::steady_clock::now();
 
     std::array<uint8_t, 64> buf {};
     buf[0] = 0x05;

--- a/src/usb.hpp
+++ b/src/usb.hpp
@@ -9,6 +9,7 @@
 #include <fcntl.h>
 
 #include <array>
+#include <chrono>
 #include <optional>
 #include <vector>
 
@@ -47,4 +48,5 @@ private:
     file_descriptor hid_fd;
     file_descriptor tfd;
     std::optional<mouse_pos_t> last_sent_pos;
+    std::chrono::steady_clock::time_point last_sent_time;
 };


### PR DESCRIPTION
# PR title

Reset border wait state after a timeout to avoid permanent mouse-switch stall

# PR description

## Problem

When the mouse hits a screen border that has **no neighbour configured** on the
WEY device (e.g. the outer edge of the layout), `lmss` sends the border-cross
command but the device — correctly — never replies with a position command
(`05 00`). Because `last_sent_pos` is only ever cleared by an incoming `05 00`
packet and there is no timeout, `lmss` stays in the "waiting" state forever and
silently drops **all** subsequent border crossings, including valid ones in
other directions. The only way to recover is a hotkey switch, which makes the
device emit a fresh `05 00`.

This is easy to hit with a single-screen source that sits at the edge of the
arrangement: one push against that dead edge disables mouse switching entirely.

## Fix

Record the timestamp when a border-cross is sent (`last_sent_time`) and, in the
USB event handler, drop `last_sent_pos` once `BORDER_RESPONSE_TIMEOUT` (500 ms)
has elapsed without a position command. After that the next border-cross is
sent normally and switching recovers on its own.

A valid cross is acknowledged by the device within a few tens of milliseconds
(observed ~30 ms), so the 500 ms margin never interferes with normal switching.

## Testing

Built from `main` on Linux Mint (X11), single 1920x1080 screen, USB Deskswitch
III (firmware V1.8).

- Pushing against a dead edge now logs
  `no position cmd within timeout, resetting border wait state` after ~500 ms,
  and the next crossing works without a hotkey.
- Valid crossings are unaffected: the device's `05 00 00 04` / `05 00 00 03`
  responses arrive long before the timeout, so the wait state is cleared by the
  response as before.

## Notes

The timeout value is a single named constant (`BORDER_RESPONSE_TIMEOUT`) in
`src/usb.cpp` and can be tuned if a different margin is preferred.