### PR TITLE
Don't reposition pointer when set to the screen we're alreafy on

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## [4.3.2] - 2026-07-08
+- don't reposition pointer when set to the screen we're already on
+
 ## [4.3.1] - 2026-06-02
 
 ### Fixed

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,7 +8,7 @@ set(CMAKE_PROJECT_DESCRIPTION
 
 set(lmss_VERSION_MAJOR 4)
 set(lmss_VERSION_MINOR 3)
-set(lmss_VERSION_PATCH 1)
+set(lmss_VERSION_PATCH 2)
 
 include(GNUInstallDirs)
 

--- a/README.md
+++ b/README.md
@@ -24,10 +24,24 @@ It works with the following products of WEY Technology AG:
     * IP Remote II DP Transmitter (Part No. 24872TDP)
     * IP Remote III 4K Transmitter (Part No. 24873T)
     * IP Remote IV Transmitter (Part No. 24874T)
+    * smartCONNECTOR B2 (Part No. 22010B2)
+
+- WEYTEC IP Remote MX Transmitter family
+    * IP Remote II DP (MX) Transmitter (Part No. 24872TDP-MX)
+    * IP Remote III 4K (MX) Transmitter (Part No. 24873T-MX)
+    * IP Remote III AV (MX) Transmitter (Part No. 24883T-MX)
+    * IP Remote IV (MX) Transmitter (Part No. 24874T-MX)
+    * smartCONNECTOR III (MX) (Part No. 22011-MX)
 
 - WEYTEC USB Deskswitch III (Part No: 22412S)
 
+⚠️ USB Deskswitch Firmware 1.9 (08.07.2026) or newer is required since LMSS 4.2.x
+
+- WEYTEC smartTOUCH (22002/22003)
+
 ⚠️ smarttouch firmware 8.7 (26.03.2024) or newer is required since LMSS 4.2.x
+
+- WEYTEC smartTOUCH (MX) (22003BK-MX)
 
 ## Installing
 
@@ -164,11 +178,11 @@ home `~/.config/autostart/`.
 
 ## Tested Distributions
 
-* Ubuntu 20.04 LTS, 22.04 LTS
+* Ubuntu 20.04 LTS, 22.04 LTS, 24.04 LTS
 * CentOS 7, 8
-* AlmaLinux 8.9
-* Rocky Linux 8
-* RHEL® 7.9
+* AlmaLinux 8, 9
+* Rocky Linux 8, 9
+* RHEL® 7.9, 8, 9
 
 Other distributions should work too, as long as X.org is used as session window
 system. The installation of the software / autostart / rights might differ per

--- a/src/display.cpp
+++ b/src/display.cpp
@@ -140,6 +140,11 @@ void display::add_monitor(int mon, int x, int y, int w, int h, Window root) {
 }
 
 void display::set_mouse_pos(mouse_pos_t const & mp) {
+    if (last_pos && get_mon_for_pos(*last_pos) == monitors[mp.screen]
+        && mp.border <= border_t::RIGHT && !hidden) {
+        return;
+    }
+
     std::stringstream ss;
     ss << "setting mouse pos on screen " << std::to_string(mp.screen)
        << " border: " << std::to_string(mp.border)


### PR DESCRIPTION
Repositioning the pointer at the border again and again will result in a jitter of the pointer and prevent any smooth moving of the pointer at a border of the screen.